### PR TITLE
Added support for Bar/Line combo charts

### DIFF
--- a/src/ChartJSCore/Models/Bar/BarDataset.cs
+++ b/src/ChartJSCore/Models/Bar/BarDataset.cs
@@ -9,6 +9,11 @@ namespace ChartJSCore.Models
 {
     public class BarDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "bar";
+
         /// <summary>
         /// The ID of the x axis to plot this dataset on.
         /// </summary>

--- a/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
@@ -9,6 +9,11 @@ namespace ChartJSCore.Models
 {
     public class BubbleDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "bubble";
+
         /// <summary>
         /// The data to plot in the bubble chart.
         /// </summary>

--- a/src/ChartJSCore/Models/Line/LineDataset.cs
+++ b/src/ChartJSCore/Models/Line/LineDataset.cs
@@ -9,6 +9,11 @@ namespace ChartJSCore.Models
 {
     public class LineDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "line";
+
         /// <summary>
         /// The ID of the x axis to plot this dataset on.
         /// </summary>

--- a/src/ChartJSCore/Models/Pie/PieDataset.cs
+++ b/src/ChartJSCore/Models/Pie/PieDataset.cs
@@ -7,6 +7,11 @@ namespace ChartJSCore.Models
 {
     public class PieDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "pie";
+
         /// <summary>
         /// The fill color of the arcs.
         /// </summary>

--- a/src/ChartJSCore/Models/Polar/PolarDataset.cs
+++ b/src/ChartJSCore/Models/Polar/PolarDataset.cs
@@ -7,6 +7,11 @@ namespace ChartJSCore.Models
 {
     public class PolarDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "polarArea";
+
         /// <summary>
         /// The fill color of the arcs.
         /// </summary>

--- a/src/ChartJSCore/Models/Radar/RadarDataset.cs
+++ b/src/ChartJSCore/Models/Radar/RadarDataset.cs
@@ -9,6 +9,11 @@ namespace ChartJSCore.Models
 {
     public class RadarDataset : Dataset
     {
+		/// <summary>
+		/// The type of the dataset
+		/// </summary>
+		public string Type { get; set; } = "radar";
+
         /// <summary>
         /// If true, fill the area under the line.
         /// </summary>


### PR DESCRIPTION
Added "Type" property with a default value to all derived dataset models, to enable support for combo charts.
See issue https://github.com/mattosaurus/ChartJSCore/issues/16