### PR TITLE
NuGet: Multi-Target net45,net46 and netstandard2.0

### DIFF
--- a/src/ChartJSCore/ChartJSCore.csproj
+++ b/src/ChartJSCore/ChartJSCore.csproj
@@ -4,7 +4,7 @@
     <Description>A .NET Core library for generating Chart.js code.</Description>
     <AssemblyTitle>ChartJSCore</AssemblyTitle>
     <VersionPrefix>1.0.3</VersionPrefix>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
     <AssemblyName>ChartJSCore</AssemblyName>
     <PackageId>ChartJSCore</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
@@ -21,14 +21,21 @@
     <FileVersion>1.3.1.0</FileVersion>
     <PackageReleaseNotes>Version 1.3.1 - LegendLabel properties corrected.</PackageReleaseNotes>
     <Authors>mattosaurus</Authors>
+    <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-
-  <Target Name="PostcompileScript" AfterTargets="Build">
-    <Exec Command="dotnet pack --no-build --configuration $(Configuration)" />
-  </Target>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also: clean up nuget package creation, remove some unused files.  On macOS, `dotnet restore` does not behave correctly while restoring packages, leaving the directory in a state where it cannot be built correctly.  Using `msbuild -t:restore` instead fixes this problem. Visual Studio on Windows should not be affected by this.