### PR TITLE
Using enum instead of string value for the chart-type

### DIFF
--- a/ChartJSCoreTest/Program.cs
+++ b/ChartJSCoreTest/Program.cs
@@ -1,12 +1,7 @@
-﻿using ChartJSCore.Helpers;
-using ChartJSCore.Models;
+﻿using ChartJSCore.Models;
 using ChartJSCore.Models.Bar;
-using ChartJSCore.Plugins;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCoreTest
 {

--- a/ChartJSCoreTest/Program.cs
+++ b/ChartJSCoreTest/Program.cs
@@ -34,7 +34,7 @@ namespace ChartJSCoreTest
         public static string GenerateBarChart()
         {
             Chart chart = new Chart();
-            chart.Type = "bar";
+            chart.Type = Enums.ChartType.BarChart;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Blue", "Yellow", "Green", "Purple", "Orange" };
@@ -113,7 +113,7 @@ namespace ChartJSCoreTest
         public static string GenerateLineChart()
         {
             Chart chart = new Chart();
-            chart.Type = "line";
+            chart.Type = Enums.ChartType.LineChart;
 
             Data data = new Data();
             data.Labels = new List<string>() { "January", "February", "March", "April", "May", "June", "July" };
@@ -183,7 +183,7 @@ namespace ChartJSCoreTest
         public static string GenerateLineScatterChart()
         {
             Chart chart = new Chart();
-            chart.Type = "line";
+            chart.Type = Enums.ChartType.LineChart;
 
             Data data = new Data();
 
@@ -247,7 +247,7 @@ namespace ChartJSCoreTest
         public static string GenerateRadarChart()
         {
             Chart chart = new Chart();
-            chart.Type = "radar";
+            chart.Type = Enums.ChartType.RadarChart;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Eating", "Drinking", "Sleeping", "Designing", "Coding", "Cycling", "Running" };
@@ -290,7 +290,7 @@ namespace ChartJSCoreTest
         public static string GeneratePolarChart()
         {
             Chart chart = new Chart();
-            chart.Type = "polarArea";
+            chart.Type = Enums.ChartType.PolarAreaChart;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Green", "Yellow", "Grey", "Blue" };
@@ -315,7 +315,7 @@ namespace ChartJSCoreTest
         public static string GeneratePieChart()
         {
             Chart chart = new Chart();
-            chart.Type = "pie";
+            chart.Type = Enums.ChartType.PieChart;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Blue", "Yellow" };
@@ -341,7 +341,7 @@ namespace ChartJSCoreTest
         public static string GenerateBubbleChart()
         {
             Chart chart = new Chart();
-            chart.Type = "bubble";
+            chart.Type = Enums.ChartType.BubbleChart;
 
             Data data = new Data();
 

--- a/ChartJSCoreTest/Program.cs
+++ b/ChartJSCoreTest/Program.cs
@@ -34,7 +34,7 @@ namespace ChartJSCoreTest
         public static string GenerateBarChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.BarChart;
+            chart.Type = Enums.ChartType.Bar;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Blue", "Yellow", "Green", "Purple", "Orange" };
@@ -113,7 +113,7 @@ namespace ChartJSCoreTest
         public static string GenerateLineChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.LineChart;
+            chart.Type = Enums.ChartType.Line;
 
             Data data = new Data();
             data.Labels = new List<string>() { "January", "February", "March", "April", "May", "June", "July" };
@@ -183,7 +183,7 @@ namespace ChartJSCoreTest
         public static string GenerateLineScatterChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.LineChart;
+            chart.Type = Enums.ChartType.Line;
 
             Data data = new Data();
 
@@ -247,7 +247,7 @@ namespace ChartJSCoreTest
         public static string GenerateRadarChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.RadarChart;
+            chart.Type = Enums.ChartType.Radar;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Eating", "Drinking", "Sleeping", "Designing", "Coding", "Cycling", "Running" };
@@ -290,7 +290,7 @@ namespace ChartJSCoreTest
         public static string GeneratePolarChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.PolarAreaChart;
+            chart.Type = Enums.ChartType.PolarArea;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Green", "Yellow", "Grey", "Blue" };
@@ -315,7 +315,7 @@ namespace ChartJSCoreTest
         public static string GeneratePieChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.PieChart;
+            chart.Type = Enums.ChartType.Pie;
 
             Data data = new Data();
             data.Labels = new List<string>() { "Red", "Blue", "Yellow" };
@@ -341,7 +341,7 @@ namespace ChartJSCoreTest
         public static string GenerateBubbleChart()
         {
             Chart chart = new Chart();
-            chart.Type = Enums.ChartType.BubbleChart;
+            chart.Type = Enums.ChartType.Bubble;
 
             Data data = new Data();
 

--- a/ChartJSCoreTest/Properties/AssemblyInfo.cs
+++ b/ChartJSCoreTest/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/ChartJSCore/Helpers/BoolIntStringConverter.cs
+++ b/src/ChartJSCore/Helpers/BoolIntStringConverter.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/CamelcaseContractResolver.cs
+++ b/src/ChartJSCore/Helpers/CamelcaseContractResolver.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/DoubleStringConverter.cs
+++ b/src/ChartJSCore/Helpers/DoubleStringConverter.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/PaddingConverter.cs
+++ b/src/ChartJSCore/Helpers/PaddingConverter.cs
@@ -1,8 +1,6 @@
 ﻿using ChartJSCore.Models;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/PlainJsonStringConverter.cs
+++ b/src/ChartJSCore/Helpers/PlainJsonStringConverter.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/PluginDynamicConverter.cs
+++ b/src/ChartJSCore/Helpers/PluginDynamicConverter.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Helpers/SingleOrArrayConverter.cs
+++ b/src/ChartJSCore/Helpers/SingleOrArrayConverter.cs
@@ -2,8 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Helpers
 {

--- a/src/ChartJSCore/Models/Bar/BarDataset.cs
+++ b/src/ChartJSCore/Models/Bar/BarDataset.cs
@@ -12,7 +12,7 @@ namespace ChartJSCore.Models
 		/// <summary>
 		/// The type of the dataset
 		/// </summary>
-		public string Type { get; set; } = "bar";
+		public Enums.ChartType Type { get; set; } = Enums.ChartType.Bar;
 
         /// <summary>
         /// The ID of the x axis to plot this dataset on.

--- a/src/ChartJSCore/Models/Bar/BarDataset.cs
+++ b/src/ChartJSCore/Models/Bar/BarDataset.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Bar/BarOptions.cs
+++ b/src/ChartJSCore/Models/Bar/BarOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models.Bar
+﻿namespace ChartJSCore.Models.Bar
 {
     public class BarOptions : Options
     {

--- a/src/ChartJSCore/Models/Base.cs
+++ b/src/ChartJSCore/Models/Base.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Bubble/BubbleData.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleData.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class BubbleData : Base
     {

--- a/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
@@ -12,7 +12,7 @@ namespace ChartJSCore.Models
 		/// <summary>
 		/// The type of the dataset
 		/// </summary>
-		public string Type { get; set; } = "bubble";
+		public Enums.ChartType Type { get; set; } = Enums.ChartType.Bubble;
 
         /// <summary>
         /// The data to plot in the bubble chart.

--- a/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Chart.cs
+++ b/src/ChartJSCore/Models/Chart.cs
@@ -30,8 +30,8 @@ namespace ChartJSCore.Models
 
         public string CreateChartCode(string canvasId)
         {
-            string code = "var " + canvasId + "Element = document.getElementById(\"" + canvasId + "\");\r\n";
-            code += "var " + canvasId + " = new Chart(" + canvasId + "Element, ";
+            string code = $"var {canvasId}Element = document.getElementById(\"{canvasId}\");\r\n";
+            code += $"var {canvasId} = new Chart({canvasId}Element, ";
 
             // keys need to be camel case to match data contract so use custom serializer to alter
             JsonSerializerSettings settings = new JsonSerializerSettings();
@@ -41,7 +41,7 @@ namespace ChartJSCore.Models
 
             string json = JsonConvert.SerializeObject(this, settings);
 
-            code += json + "\r\n";
+            code += $"{json}\r\n";
             code += ");";
 
             return code;

--- a/src/ChartJSCore/Models/Chart.cs
+++ b/src/ChartJSCore/Models/Chart.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Converters;
 
 namespace ChartJSCore.Models
 {
@@ -26,6 +27,7 @@ namespace ChartJSCore.Models
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.ContractResolver = new CamelcaseContractResolver();
             settings.NullValueHandling = NullValueHandling.Ignore;
+            settings.Converters.Add(new StringEnumConverter(true));
 
             string json = JsonConvert.SerializeObject(this, settings);
 
@@ -41,6 +43,7 @@ namespace ChartJSCore.Models
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.ContractResolver = new CamelcaseContractResolver();
             settings.NullValueHandling = NullValueHandling.Ignore;
+            settings.Converters.Add(new StringEnumConverter(true));
 
             string json = JsonConvert.SerializeObject(this, settings);
 

--- a/src/ChartJSCore/Models/Chart.cs
+++ b/src/ChartJSCore/Models/Chart.cs
@@ -11,7 +11,7 @@ namespace ChartJSCore.Models
 {
     public class Chart : Base
     {
-        public string Type { get; set; }
+        public Enums.ChartType Type { get; set; }
 
         public Data Data { get; set; }
 

--- a/src/ChartJSCore/Models/Chart.cs
+++ b/src/ChartJSCore/Models/Chart.cs
@@ -1,11 +1,5 @@
 ﻿using ChartJSCore.Helpers;
-using ChartJSCore.Plugins;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Newtonsoft.Json.Converters;
 
 namespace ChartJSCore.Models

--- a/src/ChartJSCore/Models/Data.cs
+++ b/src/ChartJSCore/Models/Data.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Dataset.cs
+++ b/src/ChartJSCore/Models/Dataset.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Enums.cs
+++ b/src/ChartJSCore/Models/Enums.cs
@@ -8,7 +8,8 @@
             BubbleChart = 1,
             RadarChart = 2,
             PolarAreaChart = 3,
-            PieChart = 4
+            PieChart = 4,
+            LineChart = 5
         }
     }
 }

--- a/src/ChartJSCore/Models/Enums.cs
+++ b/src/ChartJSCore/Models/Enums.cs
@@ -1,0 +1,14 @@
+﻿namespace ChartJSCore.Models
+{
+    public static class Enums
+    {
+        public enum ChartType : byte
+        {
+            BarChart = 0,
+            BubbleChart = 1,
+            RadarChart = 2,
+            PolarAreaChart = 3,
+            PieChart = 4
+        }
+    }
+}

--- a/src/ChartJSCore/Models/Enums.cs
+++ b/src/ChartJSCore/Models/Enums.cs
@@ -4,12 +4,13 @@
     {
         public enum ChartType : byte
         {
-            BarChart = 0,
-            BubbleChart = 1,
-            RadarChart = 2,
-            PolarAreaChart = 3,
-            PieChart = 4,
-            LineChart = 5
+            Bar = 0,
+            Bubble = 1,
+            Radar = 2,
+            PolarArea = 3,
+            Pie = 4,
+            Line = 5,
+            Doughnut = 6
         }
     }
 }

--- a/src/ChartJSCore/Models/Layout/Layout.cs
+++ b/src/ChartJSCore/Models/Layout/Layout.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Layout/Padding.cs
+++ b/src/ChartJSCore/Models/Layout/Padding.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Padding : Base
     {

--- a/src/ChartJSCore/Models/Layout/PaddingObject.cs
+++ b/src/ChartJSCore/Models/Layout/PaddingObject.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class PaddingObject : Base
     {

--- a/src/ChartJSCore/Models/Line/LineDataset.cs
+++ b/src/ChartJSCore/Models/Line/LineDataset.cs
@@ -9,10 +9,10 @@ namespace ChartJSCore.Models
 {
     public class LineDataset : Dataset
     {
-		/// <summary>
-		/// The type of the dataset
-		/// </summary>
-		public string Type { get; set; } = "line";
+        /// <summary>
+        /// The type of the dataset
+        /// </summary>
+        public Enums.ChartType Type { get; set; } = Enums.ChartType.Line;
 
         /// <summary>
         /// The ID of the x axis to plot this dataset on.

--- a/src/ChartJSCore/Models/Line/LineDataset.cs
+++ b/src/ChartJSCore/Models/Line/LineDataset.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Line/LineOptions.cs
+++ b/src/ChartJSCore/Models/Line/LineOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class LineOptions : Options
     {

--- a/src/ChartJSCore/Models/Line/LineScatterData.cs
+++ b/src/ChartJSCore/Models/Line/LineScatterData.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Line/LineScatterDataset.cs
+++ b/src/ChartJSCore/Models/Line/LineScatterDataset.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Animation/Animation.cs
+++ b/src/ChartJSCore/Models/Options/Animation/Animation.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Animation : Base
     {

--- a/src/ChartJSCore/Models/Options/Elements/Arc.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Arc.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Arc : Base
     {

--- a/src/ChartJSCore/Models/Options/Elements/Elements.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Elements.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     /// <summary>
     /// Options can be configured for four different types of elements: arc, lines, points, and rectangles. When set, these options apply to all objects of that type unless specifically overridden by the configuration attached to a dataset.

--- a/src/ChartJSCore/Models/Options/Elements/Line.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Line.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Elements/Point.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Point.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Point : Base
     {

--- a/src/ChartJSCore/Models/Options/Elements/Rectangle.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Rectangle.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Rectangle : Base
     {

--- a/src/ChartJSCore/Models/Options/Hover/Hover.cs
+++ b/src/ChartJSCore/Models/Options/Hover/Hover.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Hover : Base
     {

--- a/src/ChartJSCore/Models/Options/Legend/Legend.cs
+++ b/src/ChartJSCore/Models/Options/Legend/Legend.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Legend : Base
     {

--- a/src/ChartJSCore/Models/Options/Legend/LegendLabel.cs
+++ b/src/ChartJSCore/Models/Options/Legend/LegendLabel.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Options.cs
+++ b/src/ChartJSCore/Models/Options/Options.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/AngleLine.cs
+++ b/src/ChartJSCore/Models/Options/Scales/AngleLine.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class AngleLine : Base
     {

--- a/src/ChartJSCore/Models/Options/Scales/CartesianScale.cs
+++ b/src/ChartJSCore/Models/Options/Scales/CartesianScale.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/GridLine.cs
+++ b/src/ChartJSCore/Models/Options/Scales/GridLine.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Linear.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Linear.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Linear : RadialScale
     {

--- a/src/ChartJSCore/Models/Options/Scales/PointLabel.cs
+++ b/src/ChartJSCore/Models/Options/Scales/PointLabel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class PointLabel : Base
     {

--- a/src/ChartJSCore/Models/Options/Scales/RadialScale.cs
+++ b/src/ChartJSCore/Models/Options/Scales/RadialScale.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class RadialScale : Scale
     {

--- a/src/ChartJSCore/Models/Options/Scales/Scale.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Scale.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/ScaleLabel.cs
+++ b/src/ChartJSCore/Models/Options/Scales/ScaleLabel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class ScaleLabel : Base
     {

--- a/src/ChartJSCore/Models/Options/Scales/Scales.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Scales.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/CartesianLinearTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/CartesianLinearTick.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class CartesianLinearTick : CartesianTick
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/CartesianTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/CartesianTick.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class CartesianTick : Tick
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/CategoryTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/CategoryTick.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/LogarithmicTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/LogarithmicTick.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class LogarithmicTick : CartesianTick
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/MajorTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/MajorTick.cs
@@ -1,8 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/MinorTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/MinorTick.cs
@@ -1,8 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/RadialLinearTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/RadialLinearTick.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class RadialLinearTick : RadialTick
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/RadialTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/RadialTick.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class RadialTick : Tick
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/Tick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/Tick.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/Time.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/Time.cs
@@ -1,8 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/TimeDisplayFormat.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/TimeDisplayFormat.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class TimeDisplayFormat : Base
     {

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/TimeTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/TimeTick.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class TimeTick : CartesianTick
     {

--- a/src/ChartJSCore/Models/Options/Scales/TimeScale.cs
+++ b/src/ChartJSCore/Models/Options/Scales/TimeScale.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class TimeScale : CartesianScale
     {

--- a/src/ChartJSCore/Models/Options/Title/Title.cs
+++ b/src/ChartJSCore/Models/Options/Title/Title.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class Title : Base
     {

--- a/src/ChartJSCore/Models/Options/Tooltips/Callback.cs
+++ b/src/ChartJSCore/Models/Options/Tooltips/Callback.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Options/Tooltips/ToolTip.cs
+++ b/src/ChartJSCore/Models/Options/Tooltips/ToolTip.cs
@@ -1,9 +1,5 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Pie/PieAnimation.cs
+++ b/src/ChartJSCore/Models/Pie/PieAnimation.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class PieAnimation : Animation
     {

--- a/src/ChartJSCore/Models/Pie/PieDataset.cs
+++ b/src/ChartJSCore/Models/Pie/PieDataset.cs
@@ -7,10 +7,10 @@ namespace ChartJSCore.Models
 {
     public class PieDataset : Dataset
     {
-		/// <summary>
-		/// The type of the dataset
-		/// </summary>
-		public string Type { get; set; } = "pie";
+        /// <summary>
+        /// The type of the dataset
+        /// </summary>
+        public Enums.ChartType Type { get; set; } = Enums.ChartType.Pie;
 
         /// <summary>
         /// The fill color of the arcs.

--- a/src/ChartJSCore/Models/Pie/PieDataset.cs
+++ b/src/ChartJSCore/Models/Pie/PieDataset.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Pie/PieOptions.cs
+++ b/src/ChartJSCore/Models/Pie/PieOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class PieOptions : Options
     {

--- a/src/ChartJSCore/Models/Polar/PolarAnimation.cs
+++ b/src/ChartJSCore/Models/Polar/PolarAnimation.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models.Polar
+﻿namespace ChartJSCore.Models.Polar
 {
     public class PolarAnimation : Animation
     {

--- a/src/ChartJSCore/Models/Polar/PolarDataset.cs
+++ b/src/ChartJSCore/Models/Polar/PolarDataset.cs
@@ -7,10 +7,10 @@ namespace ChartJSCore.Models
 {
     public class PolarDataset : Dataset
     {
-		/// <summary>
-		/// The type of the dataset
-		/// </summary>
-		public string Type { get; set; } = "polarArea";
+        /// <summary>
+        /// The type of the dataset
+        /// </summary>
+        public Enums.ChartType Type { get; set; } = Enums.ChartType.PolarArea;
 
         /// <summary>
         /// The fill color of the arcs.

--- a/src/ChartJSCore/Models/Polar/PolarDataset.cs
+++ b/src/ChartJSCore/Models/Polar/PolarDataset.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Polar/PolarOptions.cs
+++ b/src/ChartJSCore/Models/Polar/PolarOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class PolarOptions : Options
     {

--- a/src/ChartJSCore/Models/Polar/PolarScale.cs
+++ b/src/ChartJSCore/Models/Polar/PolarScale.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models.Polar
+﻿namespace ChartJSCore.Models.Polar
 {
     public class PolarScale : Scale
     {

--- a/src/ChartJSCore/Models/Radar/RadarDataset.cs
+++ b/src/ChartJSCore/Models/Radar/RadarDataset.cs
@@ -9,10 +9,10 @@ namespace ChartJSCore.Models
 {
     public class RadarDataset : Dataset
     {
-		/// <summary>
-		/// The type of the dataset
-		/// </summary>
-		public string Type { get; set; } = "radar";
+        /// <summary>
+        /// The type of the dataset
+        /// </summary>
+        public Enums.ChartType Type { get; set; } = Enums.ChartType.Radar;
 
         /// <summary>
         /// If true, fill the area under the line.

--- a/src/ChartJSCore/Models/Radar/RadarDataset.cs
+++ b/src/ChartJSCore/Models/Radar/RadarDataset.cs
@@ -1,9 +1,6 @@
 ﻿using ChartJSCore.Helpers;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ChartJSCore.Models
 {

--- a/src/ChartJSCore/Models/Radar/RadarLine.cs
+++ b/src/ChartJSCore/Models/Radar/RadarLine.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class RadarLine : Line
     {

--- a/src/ChartJSCore/Models/Radar/RadarOptions.cs
+++ b/src/ChartJSCore/Models/Radar/RadarOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class RadarOptions : Options
     {

--- a/src/ChartJSCore/Plugins/PluginDynamic.cs
+++ b/src/ChartJSCore/Plugins/PluginDynamic.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Plugins
+﻿namespace ChartJSCore.Plugins
 {
     public class PluginDynamic
     {

--- a/src/ChartJSCore/Plugins/Zoom/Pan.cs
+++ b/src/ChartJSCore/Plugins/Zoom/Pan.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Plugins.Zoom
+﻿namespace ChartJSCore.Plugins.Zoom
 {
     public class Pan
     {

--- a/src/ChartJSCore/Plugins/Zoom/Range.cs
+++ b/src/ChartJSCore/Plugins/Zoom/Range.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Plugins.Zoom
+﻿namespace ChartJSCore.Plugins.Zoom
 {
     public class Range
     {

--- a/src/ChartJSCore/Plugins/Zoom/Zoom.cs
+++ b/src/ChartJSCore/Plugins/Zoom/Zoom.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Plugins.Zoom
+﻿namespace ChartJSCore.Plugins.Zoom
 {
     public class Zoom
     {

--- a/src/ChartJSCore/Plugins/Zoom/ZoomLineOptions.cs
+++ b/src/ChartJSCore/Plugins/Zoom/ZoomLineOptions.cs
@@ -1,7 +1,4 @@
 ﻿using ChartJSCore.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Plugins.Zoom
 {

--- a/src/ChartJSCore/Plugins/Zoom/ZoomOptions.cs
+++ b/src/ChartJSCore/Plugins/Zoom/ZoomOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ChartJSCore.Plugins.Zoom
+﻿namespace ChartJSCore.Plugins.Zoom
 {
     /// <summary>
     /// Requires Zoom and Pan plugin.

--- a/src/ChartJSCore/Plugins/Zoom/ZoomPieOptions.cs
+++ b/src/ChartJSCore/Plugins/Zoom/ZoomPieOptions.cs
@@ -1,7 +1,4 @@
 ﻿using ChartJSCore.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Plugins.Zoom
 {

--- a/src/ChartJSCore/Plugins/Zoom/ZoomPolarOptions.cs
+++ b/src/ChartJSCore/Plugins/Zoom/ZoomPolarOptions.cs
@@ -1,7 +1,4 @@
 ﻿using ChartJSCore.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Plugins.Zoom
 {

--- a/src/ChartJSCore/Plugins/Zoom/ZoomRadarOptions.cs
+++ b/src/ChartJSCore/Plugins/Zoom/ZoomRadarOptions.cs
@@ -1,7 +1,4 @@
 ﻿using ChartJSCore.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ChartJSCore.Plugins.Zoom
 {

--- a/src/ChartJSCore/Properties/AssemblyInfo.cs
+++ b/src/ChartJSCore/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
My contribution (my first on this platform indeed) makes setting the correct value for the type of a chart or a dataset easier (it makes setting a false value impossible). I created an enumeration with all the chart-types used in the tests. I also added the "doughnut"-type because it's properties / settings are the same as the pie-chart.

Furthermore, I removed, with the help of resharper, all unnecessary / unused using-statements in the source files