### PR TITLE
Using a custom color object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-# ChartJSCore v1.4.0
+# ChartJSCore v1.4.3
+
 Implementation of Chart.js for use with .NET Core. This library allows Chart.js code to be generated in an MVC controller from a .NET object and injected into the desired view.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/7n78iys8p8dhf9fm?svg=true)](https://ci.appveyor.com/project/perezLamed/chartjscore)
 
-# Installation
-To use ChartJSCore in your C# project, you can either download the ChartJSCore C# .NET libraries directly from the Github repository or, if you have the NuGet package manager installed, you can grab them automatically.
-* Nuget package: https://www.nuget.org/packages/ChartJSCore/ [![NuGet Badge](https://buildstats.info/nuget/ChartJSCore)](https://www.nuget.org/packages/ChartJSCore/) 
+## Installation
 
-```
+To use ChartJSCore in your C# project, you can either download the ChartJSCore C# .NET libraries directly from the Github repository or, if you have the NuGet package manager installed, you can grab them automatically.
+
+* Nuget package: <https://www.nuget.org/packages/ChartJSCore/> [![NuGet Badge](https://buildstats.info/nuget/ChartJSCore)](https://www.nuget.org/packages/ChartJSCore/)
+
+```powershell
 PM> Install-Package ChartJSCore
 ```
+
 Once you have the ChartJSCore libraries properly referenced in your project, you can include calls to them in your code.
 
 Add the following namespaces to use the library:
@@ -17,14 +21,16 @@ Add the following namespaces to use the library:
 ```C#
 using ChartJSCore.Models;
 ```
-# Dependencies
+
+## Dependencies
+
 This produces code for generating chart using Chart.js so Chart.js is required to render them, Chart.js also uses require.js so this is also needed. To install Chart.js using Bower on Visual Studio it is needed to update the registry in .bowerrc file, because the old heroku repository is deprecated as stated in [here](https://gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00). Otherwise you can download it directly to the project root folder wwwroot\lib\Chart.js.
 
 This package has been created and tested with version 2.4.0 of Chart.js, earlier versions may well be incompatible.
 
 Require.js isn't available in the Bower package manager but can be added by directly updating the bower.json file.
 
-```
+```json
 {
   "name": "asp.net",
   "private": true,
@@ -38,10 +44,13 @@ Require.js isn't available in the Bower package manager but can be added by dire
   }
 }
 ```
-# Demo
+
+## Demo
+
 This project can be seen in action on the demo site [here](https://bitscry.com/Projects/Chart).
 
-# Usage
+## Usage
+
 This is intended for usage in ASP.NET 5 Core MVC projects.
 
 Once a project has been created a new Chart object can be created by using code similar to that below. In this example the Index method of the Home controller has been updated to generate a Chart and pass it through to the relevant view.
@@ -59,21 +68,21 @@ Once a project has been created a new Chart object can be created by using code 
             LineDataset dataset = new LineDataset()
             {
                 Label = "My First dataset",
-                Data = new List<double>() { 65, 59, 80, 81, 56, 55, 40 },
-                Fill = false,
+                Data = new List<double> { 65, 59, 80, 81, 56, 55, 40 },
+                Fill = "false",
                 LineTension = 0.1,
-                BackgroundColor = "rgba(75, 192, 192, 0.4)",
-                BorderColor = "rgba(75,192,192,1)",
+                BackgroundColor = ChartColor.FromRgba(75, 192, 192, 0.4),
+                BorderColor = ChartColor.FromRgb(75,192,192),
                 BorderCapStyle = "butt",
                 BorderDash = new List<int> { },
                 BorderDashOffset = 0.0,
                 BorderJoinStyle = "miter",
-                PointBorderColor = new List<string>() { "rgba(75,192,192,1)" },
-                PointBackgroundColor = new List<string>() { "#fff" },
+                PointBorderColor = new List<ChartColor> { ChartColor.FromRgb(75,192,192) },
+                PointBackgroundColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
                 PointBorderWidth = new List<int> { 1 },
                 PointHoverRadius = new List<int> { 5 },
-                PointHoverBackgroundColor = new List<string>() { "rgba(75,192,192,1)" },
-                PointHoverBorderColor = new List<string>() { "rgba(220,220,220,1)" },
+                PointHoverBackgroundColor = new List<ChartColor> { ChartColor.FromRgb(75,192,192) },
+                PointHoverBorderColor = new List<ChartColor> { ChartColor.FromRgb(220,220,220) },
                 PointHoverBorderWidth = new List<int> { 2 },
                 PointRadius = new List<int> { 1 },
                 PointHitRadius = new List<int> { 10 },
@@ -91,7 +100,7 @@ Once a project has been created a new Chart object can be created by using code 
         }
 ```
 
-See the [test project](https://github.com/mattosaurus/ChartJSCore/blob/master/ChartJSCoreTest/Program.cs) for further examples.
+See the [test project](https://github.com/mattosaurus/ChartJSCore/tree/master/src/ChartJSCoreTest) for further examples.
 
 Within the Index view the Chart can then be accessed and rendered.
 
@@ -111,5 +120,7 @@ Within the Index view the Chart can then be accessed and rendered.
     </script>
 }
 ```
-# Plugins
+
+## Plugins
+
 As there's a large number of plugins available for Chart.js and it's not feasable to create object representations of them all I've added the "PluginDynamic" property to all chart objects to allow customisation. This is a ```Dictionary<string, object>``` in which the string is the name of the property and the object contains the object to be serialized, these will be added to the parent object as distinct properties.

--- a/src/ChartJSCore/Helpers/BoolIntStringConverter.cs
+++ b/src/ChartJSCore/Helpers/BoolIntStringConverter.cs
@@ -20,14 +20,11 @@ namespace ChartJSCore.Helpers
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            int intValue;
-            bool boolValue;
-
-            if (bool.TryParse(value.ToString(), out boolValue))
+            if (bool.TryParse(value.ToString(), out bool boolValue))
             {
                 writer.WriteValue(boolValue);
             }
-            else if (int.TryParse(value.ToString(), out intValue))
+            else if (int.TryParse(value.ToString(), out int intValue))
             {
                 if (value.ToString().StartsWith("+") || value.ToString().StartsWith("-"))
                 {

--- a/src/ChartJSCore/Helpers/ChartColor.cs
+++ b/src/ChartJSCore/Helpers/ChartColor.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Globalization;
+using Newtonsoft.Json;
 
 namespace ChartJSCore.Helpers
 {
+    [JsonConverter(typeof(ToStringJsonConverter))]
     public class ChartColor
     {
         /// <summary>
@@ -119,9 +121,9 @@ namespace ChartJSCore.Helpers
         }
 
         /// <summary>
-        /// Produces a string of the form 'rgba(r,g,b,a)'
+        /// Produces a string of the form 'rgba(r, g, b, a)'
         /// </summary>
-        /// <returns>A string of the form 'rgba(r,g,b,a)'</returns>
-        public override string ToString() => $"rgba({Red},{Green},{Blue},{Alpha})";
+        /// <returns>A string of the form 'rgba(r, g, b, a)'</returns>
+        public override string ToString() => $"rgba({Red}, {Green}, {Blue}, {Alpha})";
     }
 }

--- a/src/ChartJSCore/Helpers/ChartColor.cs
+++ b/src/ChartJSCore/Helpers/ChartColor.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Globalization;
+
+namespace ChartJSCore.Helpers
+{
+    public class ChartColor
+    {
+        /// <summary>
+        /// The red (r) value of the color
+        /// Has a value between 0 and 256
+        /// </summary>
+        public byte Red { get; set; } = 0;
+
+        /// <summary>
+        /// The green (g) value of the color
+        /// Has a value between 0 and 256
+        /// </summary>
+        public byte Green { get; set; } = 0;
+
+        /// <summary>
+        /// The blue (b) value of the color
+        /// Has a value between 0 and 256
+        /// </summary>
+        public byte Blue { get; set; } = 0;
+
+        /// <summary>
+        /// The alpha (a) value of the color which specifies the opacity
+        /// Has a value between 0.0 and 1.0
+        /// </summary>
+        public double Alpha { get; set; } = 0.1;
+
+
+        /// <summary>
+        /// Creates a new color with the specified values.
+        /// The alpha-value (<see cref="a"/>) must be between 0.0 and 1.0
+        /// </summary>
+        /// <param name="r">The red (r) value of the color</param>
+        /// <param name="g">The green (g) value of the color</param>
+        /// <param name="b">The blue (b) value of the color</param>
+        /// <param name="a">he alpha (a) value of the color which specifies the opacity. Has a value between 0.0 and 1.0.</param>
+        /// <returns>A new color with the specified values</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Throws when the alpha value has an invalid value</exception>
+        public static ChartColor FromRgba(byte r, byte g, byte b, double a)
+        {
+            if (a < 0 || a > 1)
+                throw new ArgumentOutOfRangeException("The alpha value must be a value between 0.0 and 1.0", nameof(a));
+
+            return new ChartColor { Red = r, Green = g, Blue = b, Alpha = a };
+        }
+
+
+        /// <summary>
+        /// Creates a new color with the specified values and the alpha fixed at 1.0 (fully opaque).
+        /// </summary>
+        /// <param name="r">The red (r) value of the color</param>
+        /// <param name="g">The green (g) value of the color</param>
+        /// <param name="b">The blue (b) value of the color</param>
+        /// <returns>A new color with the specified values and alpha = 1.0 (fully opaque).</returns>
+        public static ChartColor FromRgb(byte r, byte g, byte b) => new ChartColor { Red = r, Green = g, Blue = b, Alpha = 1 };
+
+
+        /// <summary>
+        /// Creates a new color with the specified values and the alpha fixed at 1.0 (fully opaque).
+        /// </summary>
+        /// <param name="hexString">The color in hexadecimal representation in the format #aabbcc</param>
+        /// <returns>A new color with the specified values and alpha = 1.0</returns>
+        /// <exception cref="FormatException">Throws when the hex-string has an invalid format</exception>
+        public static ChartColor FromHexString(string hexString)
+        {
+            var color = new ChartColor();
+
+            try
+            {
+                hexString = hexString.Remove(0, 1);
+                if (hexString.Length == 6)
+                {
+                    color.Red = byte.Parse(hexString.Substring(0, 2), NumberStyles.HexNumber);
+                    color.Green = byte.Parse(hexString.Substring(2, 2), NumberStyles.HexNumber);
+                    color.Blue = byte.Parse(hexString.Substring(4, 2), NumberStyles.HexNumber);
+                    color.Alpha = 1;
+
+                    return color;
+                }
+            }
+            catch (FormatException)
+            {
+                // Could not parse the hex-string.
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Could not parse the hex-string.
+            }
+            catch (ArgumentNullException)
+            {
+                // Could not parse the hex-string.
+            }
+
+            throw new FormatException("The hex string has an invalid format. It has to contain 3 or 4 numbers encoded in hex.");
+        }
+
+
+        /// <summary>
+        /// Creates a new color with random values for r, g, b and a.
+        /// </summary>
+        /// <param name="randomAlpha">Specifies whether a random alpha (between 0.0 and 1.0) or a fixed at 1.0 should be chosen.</param>
+        /// <returns>A new color with random values</returns>
+        public static ChartColor CreateRandomChartColor(bool randomAlpha)
+        {
+            var rand = new Random();
+            return new ChartColor
+            {
+                Red = (byte)rand.Next(0, 256),
+                Green = (byte)rand.Next(0, 256),
+                Blue = (byte)rand.Next(0, 256),
+                Alpha = randomAlpha 
+                    ? rand.NextDouble() 
+                    : 1.0
+            };
+        }
+
+        /// <summary>
+        /// Produces a string of the form 'rgba(r,g,b,a)'
+        /// </summary>
+        /// <returns>A string of the form 'rgba(r,g,b,a)'</returns>
+        public override string ToString() => $"rgba({Red},{Green},{Blue},{Alpha})";
+    }
+}

--- a/src/ChartJSCore/Helpers/ToStringJsonConverter.cs
+++ b/src/ChartJSCore/Helpers/ToStringJsonConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ChartJSCore.Helpers
+{
+    internal class ToStringJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => true;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override bool CanRead => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ChartJSCore/Models/Bar/BarDataset.cs
+++ b/src/ChartJSCore/Models/Bar/BarDataset.cs
@@ -24,14 +24,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color of the bars.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> BackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> BackgroundColor { get; set; }
 
         /// <summary>
         /// Bar border color.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> BorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> BorderColor { get; set; }
 
         /// <summary>
         /// Border width of bar in pixels.
@@ -48,14 +48,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Bar background color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> HoverBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Bar border color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> HoverBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> HoverBorderColor { get; set; }
 
         /// <summary>
         /// Border width of bar when hovered.

--- a/src/ChartJSCore/Models/Bubble/BubbleData.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleData.cs
@@ -2,10 +2,10 @@
 {
     public class BubbleData : Base
     {
-        public double x { get; set; }
+        public double X { get; set; }
 
-        public double y { get; set; }
+        public double Y { get; set; }
 
-        public double r { get; set; }
+        public double R { get; set; }
     }
 }

--- a/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
+++ b/src/ChartJSCore/Models/Bubble/BubbleDataset.cs
@@ -19,14 +19,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color of the bubbles.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> BackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> BackgroundColor { get; set; }
 
         /// <summary>
         /// The stroke color of the bubbles.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> BorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> BorderColor { get; set; }
 
         /// <summary>
         /// The stroke width of bubble in pixels.
@@ -37,14 +37,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color of the bubbles when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> HoverBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// The stroke color of the bubbles when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> HoverBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> HoverBorderColor { get; set; }
 
         /// <summary>
         /// The stroke width of the bubbles when hovered.

--- a/src/ChartJSCore/Models/Data.cs
+++ b/src/ChartJSCore/Models/Data.cs
@@ -2,7 +2,6 @@
 
 namespace ChartJSCore.Models
 {
-    // TODO: Implement color object rather than using string.
     // TODO: Implement mixed chart types.
     public class Data : Base
     {

--- a/src/ChartJSCore/Models/Line/LineDataset.cs
+++ b/src/ChartJSCore/Models/Line/LineDataset.cs
@@ -40,7 +40,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color under the line.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// The width of the line in pixels.
@@ -50,7 +50,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The color of the line.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Cap style of the line.
@@ -75,14 +75,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The border color for points.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointBorderColor { get; set; }
 
         /// <summary>
         /// The fill color for points.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointBackgroundColor { get; set; }
 
         /// <summary>
         /// The width of the point border in pixels.
@@ -111,14 +111,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Point background color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointHoverBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointHoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Point border color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointHoverBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointHoverBorderColor { get; set; }
 
         /// <summary>
         /// Border width of point when hovered.

--- a/src/ChartJSCore/Models/Line/LineScatterData.cs
+++ b/src/ChartJSCore/Models/Line/LineScatterData.cs
@@ -6,9 +6,9 @@ namespace ChartJSCore.Models
     public class LineScatterData : Base
     {
         [JsonConverter(typeof(DoubleStringConverter))]
-        public string x { get; set; }
+        public string X { get; set; }
 
         [JsonConverter(typeof(DoubleStringConverter))]
-        public string y { get; set; }
+        public string Y { get; set; }
     }
 }

--- a/src/ChartJSCore/Models/Options/Elements/Arc.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Arc.cs
@@ -1,16 +1,18 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class Arc : Base
     {
         /// <summary>
         /// Default fill color for arcs. Inherited from the global default.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// Default stroke color for arcs.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Default stroke width for arcs.

--- a/src/ChartJSCore/Models/Options/Elements/Line.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Line.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 
 namespace ChartJSCore.Models
 {
@@ -12,7 +13,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Default line fill color.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// Default line stroke width.
@@ -22,7 +23,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Default line stroke color.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Default line cap style.

--- a/src/ChartJSCore/Models/Options/Elements/Point.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Point.cs
@@ -1,4 +1,6 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class Point : Base
     {
@@ -15,7 +17,7 @@
         /// <summary>
         /// Default point fill color.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// Default point stroke width.
@@ -25,7 +27,7 @@
         /// <summary>
         /// Default point stroke color.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Extra radius added to point radius for hit detection.

--- a/src/ChartJSCore/Models/Options/Elements/Rectangle.cs
+++ b/src/ChartJSCore/Models/Options/Elements/Rectangle.cs
@@ -1,11 +1,13 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class Rectangle : Base
     {
         /// <summary>
         /// Default bar fill color.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// Default bar stroke width.
@@ -15,7 +17,7 @@
         /// <summary>
         /// Default bar stroke color.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Default skipped (excluded) border for rectangle. Can be one of bottom, left, top, right.

--- a/src/ChartJSCore/Models/Options/Legend/LegendLabel.cs
+++ b/src/ChartJSCore/Models/Options/Legend/LegendLabel.cs
@@ -23,7 +23,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color inherited from global configuration.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family inherited from global configuration.

--- a/src/ChartJSCore/Models/Options/Scales/AngleLine.cs
+++ b/src/ChartJSCore/Models/Options/Scales/AngleLine.cs
@@ -1,4 +1,6 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class AngleLine : Base
     {
@@ -10,7 +12,7 @@
         /// <summary>
         /// Color of angled lines.
         /// </summary>
-        public string Color { get; set; }
+        public ChartColor Color { get; set; }
 
         /// <summary>
         /// Width of angled lines.

--- a/src/ChartJSCore/Models/Options/Scales/CartesianScale.cs
+++ b/src/ChartJSCore/Models/Options/Scales/CartesianScale.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace ChartJSCore.Models
+﻿namespace ChartJSCore.Models
 {
     public class CartesianScale : Scale
     {

--- a/src/ChartJSCore/Models/Options/Scales/GridLine.cs
+++ b/src/ChartJSCore/Models/Options/Scales/GridLine.cs
@@ -19,8 +19,8 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Color of the grid lines.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> Color { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> Color { get; set; }
 
         /// <summary>
         /// Length and spacing of dashes.
@@ -66,7 +66,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Stroke color of the grid line for the first index (index 0).
         /// </summary>
-        public string ZeroLineColor { get; set; }
+        public ChartColor ZeroLineColor { get; set; }
 
         /// <summary>
         /// Length and spacing of dashes of the grid line for the first index (index 0).

--- a/src/ChartJSCore/Models/Options/Scales/PointLabel.cs
+++ b/src/ChartJSCore/Models/Options/Scales/PointLabel.cs
@@ -1,4 +1,6 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class PointLabel : Base
     {
@@ -10,7 +12,7 @@
         /// <summary>
         /// Font color.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family to render.

--- a/src/ChartJSCore/Models/Options/Scales/ScaleLabel.cs
+++ b/src/ChartJSCore/Models/Options/Scales/ScaleLabel.cs
@@ -1,4 +1,6 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class ScaleLabel : Base
     {
@@ -12,7 +14,7 @@
         /// <summary>
         /// Font color for the scale title.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family for the scale title, follows CSS font-family options.

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/MajorTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/MajorTick.cs
@@ -14,7 +14,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tick labels.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family for the tick labels, follows CSS font-family options.

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/MinorTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/MinorTick.cs
@@ -14,7 +14,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tick labels.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family for the tick labels, follows CSS font-family options.

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/RadialLinearTick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/RadialLinearTick.cs
@@ -1,11 +1,13 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class RadialLinearTick : RadialTick
     {
         /// <summary>
         /// Color of label backdrops.
         /// </summary>
-        public string BackdropColor { get; set; }
+        public ChartColor BackdropColor { get; set; }
 
         /// <summary>
         /// Horizontal padding of label backdrop.

--- a/src/ChartJSCore/Models/Options/Scales/Ticks/Tick.cs
+++ b/src/ChartJSCore/Models/Options/Scales/Ticks/Tick.cs
@@ -19,7 +19,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tick labels.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font family for the tick labels, follows CSS font-family options.

--- a/src/ChartJSCore/Models/Options/Title/Title.cs
+++ b/src/ChartJSCore/Models/Options/Title/Title.cs
@@ -1,4 +1,6 @@
-﻿namespace ChartJSCore.Models
+﻿using ChartJSCore.Helpers;
+
+namespace ChartJSCore.Models
 {
     public class Title : Base
     {
@@ -30,7 +32,7 @@
         /// <summary>
         /// Font color inherited from global configuration.
         /// </summary>
-        public string FontColor { get; set; }
+        public ChartColor FontColor { get; set; }
 
         /// <summary>
         /// Font styling of the title.

--- a/src/ChartJSCore/Models/Options/Tooltips/ToolTip.cs
+++ b/src/ChartJSCore/Models/Options/Tooltips/ToolTip.cs
@@ -41,7 +41,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Background color of the tooltip.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// Font family for tooltip title inherited from global font family.
@@ -61,7 +61,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tooltip title.
         /// </summary>
-        public string TitleFontColor { get; set; }
+        public ChartColor TitleFontColor { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each title line.
@@ -91,7 +91,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tooltip items.
         /// </summary>
-        public string BodyFontColor { get; set; }
+        public ChartColor BodyFontColor { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each tooltip item.
@@ -116,7 +116,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Font color for tooltip footer.
         /// </summary>
-        public string FooterFontColor { get; set; }
+        public ChartColor FooterFontColor { get; set; }
 
         /// <summary>
         /// Spacing to add to top and bottom of each footer line.
@@ -151,7 +151,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Color to draw behind the colored boxes when multiple items are in the tooltip.
         /// </summary>
-        public string MultiKeyBackground { get; set; }
+        public ChartColor MultiKeyBackground { get; set; }
 
         /// <summary>
         /// if true, color boxes are shown in the tooltip.

--- a/src/ChartJSCore/Models/Pie/PieDataset.cs
+++ b/src/ChartJSCore/Models/Pie/PieDataset.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 
 namespace ChartJSCore.Models
 {
@@ -12,12 +13,12 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color of the arcs.
         /// </summary>
-        public IList<string> BackgroundColor { get; set; }
+        public IList<ChartColor> BackgroundColor { get; set; }
 
         /// <summary>
         /// Arc border color.
         /// </summary>
-        public IList<string> BorderColor { get; set; }
+        public IList<ChartColor> BorderColor { get; set; }
 
         /// <summary>
         /// Border width of arcs in pixels.
@@ -27,12 +28,12 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Arc background color when hovered.
         /// </summary>
-        public IList<string> HoverBackgroundColor { get; set; }
+        public IList<ChartColor> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Arc border color when hovered.
         /// </summary>
-        public IList<string> HoverBorderColor { get; set; }
+        public IList<ChartColor> HoverBorderColor { get; set; }
 
         /// <summary>
         /// Border width of arc when hovered.

--- a/src/ChartJSCore/Models/Polar/PolarDataset.cs
+++ b/src/ChartJSCore/Models/Polar/PolarDataset.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 
 namespace ChartJSCore.Models
 {
@@ -12,12 +13,12 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color of the arcs.
         /// </summary>
-        public IList<string> BackgroundColor { get; set; }
+        public IList<ChartColor> BackgroundColor { get; set; }
 
         /// <summary>
         /// Arc border color.
         /// </summary>
-        public IList<string> BorderColor { get; set; }
+        public IList<ChartColor> BorderColor { get; set; }
 
         /// <summary>
         /// Border width of arcs in pixels.
@@ -27,12 +28,12 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Arc background color when hovered.
         /// </summary>
-        public IList<string> HoverBackgroundColor { get; set; }
+        public IList<ChartColor> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Arc border color when hovered.
         /// </summary>
-        public IList<string> HoverBorderColor { get; set; }
+        public IList<ChartColor> HoverBorderColor { get; set; }
 
         /// <summary>
         /// Border width of arc when hovered.

--- a/src/ChartJSCore/Models/Radar/RadarDataset.cs
+++ b/src/ChartJSCore/Models/Radar/RadarDataset.cs
@@ -24,7 +24,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The fill color under the line.
         /// </summary>
-        public string BackgroundColor { get; set; }
+        public ChartColor BackgroundColor { get; set; }
 
         /// <summary>
         /// The width of the line in pixels.
@@ -34,7 +34,7 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The color of the line.
         /// </summary>
-        public string BorderColor { get; set; }
+        public ChartColor BorderColor { get; set; }
 
         /// <summary>
         /// Cap style of the line.
@@ -59,14 +59,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// The border color for points.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointBorderColor { get; set; }
 
         /// <summary>
         /// The fill color for points.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointBackgroundColor { get; set; }
 
         /// <summary>
         /// The width of the point border in pixels.
@@ -95,14 +95,14 @@ namespace ChartJSCore.Models
         /// <summary>
         /// Point background color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointHoverBackgroundColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointHoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Point border color when hovered.
         /// </summary>
-        [JsonConverter(typeof(SingleOrArrayConverter<string>))]
-        public IList<string> PointHoverBorderColor { get; set; }
+        [JsonConverter(typeof(SingleOrArrayConverter<ChartColor>))]
+        public IList<ChartColor> PointHoverBorderColor { get; set; }
 
         /// <summary>
         /// Border width of point when hovered.

--- a/src/ChartJSCoreTest/BarChartTests.cs
+++ b/src/ChartJSCoreTest/BarChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using ChartJSCore.Models.Bar;
 using NUnit.Framework;
@@ -8,7 +9,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class BarChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var barChartElement = document.getElementById(\"barChart\");\r\nvar barChart = new Chart(barChartElement, {\"type\":\"bar\",\"data\":{\"datasets\":[{\"type\":\"bar\",\"backgroundColor\":[\"rgba(255, 99, 132, 0.2)\",\"rgba(54, 162, 235, 0.2)\",\"rgba(255, 206, 86, 0.2)\",\"rgba(75, 192, 192, 0.2)\",\"rgba(153, 102, 255, 0.2)\",\"rgba(255, 159, 64, 0.2)\"],\"borderColor\":[\"rgba(255,99,132,1)\",\"rgba(54, 162, 235, 1)\",\"rgba(255, 206, 86, 1)\",\"rgba(75, 192, 192, 1)\",\"rgba(153, 102, 255, 1)\",\"rgba(255, 159, 64, 1)\"],\"borderWidth\":1,\"data\":[12.0,19.0,3.0,5.0,2.0,3.0],\"label\":\"# of Votes\"}],\"labels\":[\"Red\",\"Blue\",\"Yellow\",\"Green\",\"Purple\",\"Orange\"]},\"options\":{\"barPercentage\":0.7,\"layout\":{\"padding\":{\"left\":10,\"right\":12}},\"scales\":{\"yAxes\":[{\"ticks\":{\"beginAtZero\":true}}]}}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var barChartElement = document.getElementById(\"barChart\");\r\nvar barChart = new Chart(barChartElement, {\"type\":\"bar\",\"data\":{\"datasets\":[{\"type\":\"bar\",\"backgroundColor\":[\"rgba(255, 99, 132, 0.2)\",\"rgba(54, 162, 235, 0.2)\",\"rgba(255, 206, 86, 0.2)\",\"rgba(75, 192, 192, 0.2)\",\"rgba(153, 102, 255, 0.2)\",\"rgba(255, 159, 64, 0.2)\"],\"borderColor\":[\"rgba(255, 99, 132, 1)\",\"rgba(54, 162, 235, 1)\",\"rgba(255, 206, 86, 1)\",\"rgba(75, 192, 192, 1)\",\"rgba(153, 102, 255, 1)\",\"rgba(255, 159, 64, 1)\"],\"borderWidth\":1,\"data\":[12.0,19.0,3.0,5.0,2.0,3.0],\"label\":\"# of Votes\"}],\"labels\":[\"Red\",\"Blue\",\"Yellow\",\"Green\",\"Purple\",\"Orange\"]},\"options\":{\"barPercentage\":0.7,\"layout\":{\"padding\":{\"left\":10,\"right\":12}},\"scales\":{\"yAxes\":[{\"ticks\":{\"beginAtZero\":true}}]}}}\r\n);";
 
         [Test]
         public void Generate_BarChart_Generates_Valid_Chart()
@@ -41,28 +42,28 @@ namespace ChartJSCoreTest
             {
                 Label = "# of Votes",
                 Data = new List<double> { 12, 19, 3, 5, 2, 3 },
-                BackgroundColor = new List<string>
+                BackgroundColor = new List<ChartColor>
                 {
-                        "rgba(255, 99, 132, 0.2)",
-                        "rgba(54, 162, 235, 0.2)",
-                        "rgba(255, 206, 86, 0.2)",
-                        "rgba(75, 192, 192, 0.2)",
-                        "rgba(153, 102, 255, 0.2)",
-                        "rgba(255, 159, 64, 0.2)"
-                        },
-                BorderColor = new List<string>
+                    ChartColor.FromRgba(255, 99, 132, 0.2),
+                    ChartColor.FromRgba(54, 162, 235, 0.2),
+                    ChartColor.FromRgba(255, 206, 86, 0.2),
+                    ChartColor.FromRgba(75, 192, 192, 0.2),
+                    ChartColor.FromRgba(153, 102, 255, 0.2),
+                    ChartColor.FromRgba(255, 159, 64, 0.2)
+                },
+                BorderColor = new List<ChartColor>
                 {
-                        "rgba(255,99,132,1)",
-                        "rgba(54, 162, 235, 1)",
-                        "rgba(255, 206, 86, 1)",
-                        "rgba(75, 192, 192, 1)",
-                        "rgba(153, 102, 255, 1)",
-                        "rgba(255, 159, 64, 1)"
-                        },
+                    ChartColor.FromRgb(255, 99, 132),
+                    ChartColor.FromRgb(54, 162, 235),
+                    ChartColor.FromRgb(255, 206, 86),
+                    ChartColor.FromRgb(75, 192, 192),
+                    ChartColor.FromRgb(153, 102, 255),
+                    ChartColor.FromRgb(255, 159, 64)
+                },
                 BorderWidth = new List<int> { 1 }
             };
 
-            data.Datasets = new List<Dataset> {dataset};
+            data.Datasets = new List<Dataset> { dataset };
 
             chart.Data = data;
 

--- a/src/ChartJSCoreTest/BubbleChartTests.cs
+++ b/src/ChartJSCoreTest/BubbleChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using NUnit.Framework;
 
@@ -7,7 +8,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class BubbleChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var bubbleChartElement = document.getElementById(\"bubbleChart\");\r\nvar bubbleChart = new Chart(bubbleChartElement, {\"type\":\"bubble\",\"data\":{\"datasets\":[{\"type\":\"bubble\",\"data\":[{\"x\":20.0,\"y\":30.0,\"r\":15.0},{\"x\":40.0,\"y\":10.0,\"r\":10.0}],\"backgroundColor\":\"#FF6384\",\"hoverBackgroundColor\":\"#FF6384\",\"label\":\"Bubble Dataset\"}]},\"options\":{}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var bubbleChartElement = document.getElementById(\"bubbleChart\");\r\nvar bubbleChart = new Chart(bubbleChartElement, {\"type\":\"bubble\",\"data\":{\"datasets\":[{\"type\":\"bubble\",\"data\":[{\"x\":20.0,\"y\":30.0,\"r\":15.0},{\"x\":40.0,\"y\":10.0,\"r\":10.0}],\"backgroundColor\":\"rgba(255, 99, 132, 1)\",\"hoverBackgroundColor\":\"rgba(255, 99, 132, 1)\",\"label\":\"Bubble Dataset\"}]},\"options\":{}}\r\n);";
 
         [Test]
         public void Generate_BubbleChart_Generates_Valid_Chart()
@@ -34,20 +35,20 @@ namespace ChartJSCoreTest
             var bubbleData1 = new BubbleData();
             var bubbleData2 = new BubbleData();
 
-            bubbleData1.x = 20;
-            bubbleData1.y = 30;
-            bubbleData1.r = 15;
+            bubbleData1.X = 20;
+            bubbleData1.Y = 30;
+            bubbleData1.R = 15;
             dataset.Data.Add(bubbleData1);
 
-            bubbleData2.x = 40;
-            bubbleData2.y = 10;
-            bubbleData2.r = 10;
+            bubbleData2.X = 40;
+            bubbleData2.Y = 10;
+            bubbleData2.R = 10;
             dataset.Data.Add(bubbleData2);
 
             data.Datasets = new List<Dataset> { dataset };
 
-            dataset.BackgroundColor = new List<string> { "#FF6384" };
-            dataset.HoverBackgroundColor = new List<string> { "#FF6384" };
+            dataset.BackgroundColor = new List<ChartColor> { ChartColor.FromRgb(255, 99, 132) };
+            dataset.HoverBackgroundColor = new List<ChartColor> { ChartColor.FromRgb(255, 99, 132) };
 
             chart.Data = data;
 

--- a/src/ChartJSCoreTest/ChartColorTests.cs
+++ b/src/ChartJSCoreTest/ChartColorTests.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using ChartJSCore.Helpers;
+using NUnit.Framework;
+
+namespace ChartJSCoreTest
+{
+    [TestFixture]
+    public class ChartColorTests
+    {
+        [Test]
+        public void Too_Big_Alpha_Throws_ArgumentOutOfRangeException()
+        {
+            byte red = 0;
+            byte green = 0;
+            byte blue = 0;
+            double alpha = 1.1;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ChartColor.FromRgba(red, green, blue, alpha));
+        }
+
+        [Test]
+        public void Too_Small_Alpha_Throws_ArgumentOutOfRangeException()
+        {
+            byte red = 0;
+            byte green = 0;
+            byte blue = 0;
+            double alpha = -5;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ChartColor.FromRgba(red, green, blue, alpha));
+        }
+
+        [Test]
+        public void FromRgba_Populates_Correct_Values()
+        {
+            byte expectedRed = 187;
+            byte expectedGreen = 55;
+            byte expectedBlue = 4;
+            double expectedAlpha = 0.65;
+
+            var actualColor = ChartColor.FromRgba(expectedRed, expectedGreen, expectedBlue, expectedAlpha);
+
+            Assert.AreEqual(expectedRed, actualColor.Red);
+            Assert.AreEqual(expectedGreen, actualColor.Green);
+            Assert.AreEqual(expectedBlue, actualColor.Blue);
+            Assert.AreEqual(expectedAlpha, actualColor.Alpha);
+        }
+
+        [Test]
+        public void FromRgb_Populates_Correct_Values()
+        {
+            byte expectedRed = 66;
+            byte expectedGreen = 99;
+            byte expectedBlue = 111;
+
+            var actualColor = ChartColor.FromRgb(expectedRed, expectedGreen, expectedBlue);
+
+            Assert.AreEqual(expectedRed, actualColor.Red);
+            Assert.AreEqual(expectedGreen, actualColor.Green);
+            Assert.AreEqual(expectedBlue, actualColor.Blue);
+        }
+
+        [Test]
+        public void FromRgb_Populates_Alpha_With_One()
+        {
+            double expectedAlpha = 1.0;
+
+            var actualColor = ChartColor.FromRgb(0, 0, 0);
+
+            Assert.AreEqual(expectedAlpha, actualColor.Alpha);
+        }
+
+        [Test]
+        public void FromHexString_Throws_FormatException_Without_Hex_Specifier()
+        {
+            string hexString = "12abef";
+
+            Assert.Throws<FormatException>(() => ChartColor.FromHexString(hexString));
+        }
+
+
+        [Test]
+        public void FromHexString_Throws_FormatException_With_False_Length()
+        {
+            string tooShortHexString = "#12abe";
+            string tooLongHexString = "#12abefa";
+
+            Assert.Throws<FormatException>(() => ChartColor.FromHexString(tooShortHexString));
+            Assert.Throws<FormatException>(() => ChartColor.FromHexString(tooLongHexString));
+        }
+
+        [Test]
+        public void FromHexString_Throws_FormatException_Invalid_Hex_Character()
+        {
+            string invalidHexString = "#12abex";
+
+            Assert.Throws<FormatException>(() => ChartColor.FromHexString(invalidHexString));
+        }
+
+        [Test]
+        public void FromHexString_Populates_Correct_Values()
+        {
+            byte expectedRed = 154;
+            byte expectedGreen = 89;
+            byte expectedBlue = 77;
+            double expectedAlpha = 1.0;
+
+            var actualColor = ChartColor.FromHexString($"#{expectedRed:X}{expectedGreen:X}{expectedBlue:X}");
+
+            Assert.AreEqual(expectedRed, actualColor.Red);
+            Assert.AreEqual(expectedGreen, actualColor.Green);
+            Assert.AreEqual(expectedBlue, actualColor.Blue);
+            Assert.AreEqual(expectedAlpha, actualColor.Alpha);
+        }
+
+        [Test]
+        public void GetRandomChartColor_With_Random_Alpha_Returns_Values_In_Boundry()
+        {
+            var randomColor = ChartColor.CreateRandomChartColor(true);
+
+            Assert.That(randomColor.Red, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.That(randomColor.Green, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.That(randomColor.Blue, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.That(randomColor.Alpha, Is.GreaterThanOrEqualTo(0.0).And.LessThanOrEqualTo(1.0));
+        }
+
+        [Test]
+        public void GetRandomChartColor_Without_Random_Alpha_Returns_Values_In_Boundry_And_Alpha_One()
+        {
+            double expectedAlpha = 1.0;
+
+            var randomColor = ChartColor.CreateRandomChartColor(false);
+
+            Assert.That(randomColor.Red, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.That(randomColor.Green, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.That(randomColor.Blue, Is.GreaterThanOrEqualTo(0).And.LessThanOrEqualTo(256));
+            Assert.AreEqual(randomColor.Alpha, expectedAlpha);
+        }
+
+        [Test]
+        public void ToString_Returns_Correct_Rgba_String_Representation()
+        {
+            byte red = 4;
+            byte green = 65;
+            byte blue = 154;
+            double alpha = 0.232;
+
+            string expectedString = $"rgba({red},{green},{blue},{alpha})";
+
+            var color = ChartColor.FromRgba(red, green, blue, alpha);
+            var actualString = color.ToString();
+
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/src/ChartJSCoreTest/ChartColorTests.cs
+++ b/src/ChartJSCoreTest/ChartColorTests.cs
@@ -144,7 +144,7 @@ namespace ChartJSCoreTest
             byte blue = 154;
             double alpha = 0.232;
 
-            string expectedString = $"rgba({red},{green},{blue},{alpha})";
+            string expectedString = $"rgba({red}, {green}, {blue}, {alpha})";
 
             var color = ChartColor.FromRgba(red, green, blue, alpha);
             var actualString = color.ToString();

--- a/src/ChartJSCoreTest/LineChartTests.cs
+++ b/src/ChartJSCoreTest/LineChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using NUnit.Framework;
 
@@ -7,7 +8,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class LineChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var lineChartElement = document.getElementById(\"lineChart\");\r\nvar lineChart = new Chart(lineChartElement, {\"type\":\"line\",\"data\":{\"datasets\":[{\"type\":\"line\",\"fill\":false,\"lineTension\":0.1,\"backgroundColor\":\"rgba(75, 192, 192, 0.4)\",\"borderColor\":\"rgba(75,192,192,1)\",\"borderCapStyle\":\"butt\",\"borderDash\":[],\"borderDashOffset\":0.0,\"borderJoinStyle\":\"miter\",\"pointBorderColor\":\"rgba(75,192,192,1)\",\"pointBackgroundColor\":\"#fff\",\"pointBorderWidth\":1,\"pointRadius\":1,\"pointHoverRadius\":5,\"pointHitRadius\":10,\"pointHoverBackgroundColor\":\"rgba(75,192,192,1)\",\"pointHoverBorderColor\":\"rgba(220,220,220,1)\",\"pointHoverBorderWidth\":2,\"spanGaps\":false,\"data\":[65.0,59.0,80.0,81.0,56.0,55.0,40.0],\"label\":\"My First dataset\"}],\"labels\":[\"January\",\"February\",\"March\",\"April\",\"May\",\"June\",\"July\"]},\"options\":{\"scales\":{\"yAxes\":[{\"ticks\":{\"callback\":function(value, index, values) {return '$' + value;}}}]}}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var lineChartElement = document.getElementById(\"lineChart\");\r\nvar lineChart = new Chart(lineChartElement, {\"type\":\"line\",\"data\":{\"datasets\":[{\"type\":\"line\",\"fill\":false,\"lineTension\":0.1,\"backgroundColor\":\"rgba(75, 192, 192, 0.4)\",\"borderColor\":\"rgba(75, 192, 192, 1)\",\"borderCapStyle\":\"butt\",\"borderDash\":[],\"borderDashOffset\":0.0,\"borderJoinStyle\":\"miter\",\"pointBorderColor\":\"rgba(75, 192, 192, 1)\",\"pointBackgroundColor\":\"rgba(255, 255, 255, 1)\",\"pointBorderWidth\":1,\"pointRadius\":1,\"pointHoverRadius\":5,\"pointHitRadius\":10,\"pointHoverBackgroundColor\":\"rgba(75, 192, 192, 1)\",\"pointHoverBorderColor\":\"rgba(220, 220, 220, 1)\",\"pointHoverBorderWidth\":2,\"spanGaps\":false,\"data\":[65.0,59.0,80.0,81.0,56.0,55.0,40.0],\"label\":\"My First dataset\"}],\"labels\":[\"January\",\"February\",\"March\",\"April\",\"May\",\"June\",\"July\"]},\"options\":{\"scales\":{\"yAxes\":[{\"ticks\":{\"callback\":function(value, index, values) {return '$' + value;}}}]}}}\r\n);";
 
         [Test]
         public void Generate_LineChart_Generates_Valid_Chart()
@@ -43,18 +44,18 @@ namespace ChartJSCoreTest
                 Data = new List<double> { 65, 59, 80, 81, 56, 55, 40 },
                 Fill = "false",
                 LineTension = 0.1,
-                BackgroundColor = "rgba(75, 192, 192, 0.4)",
-                BorderColor = "rgba(75,192,192,1)",
+                BackgroundColor = ChartColor.FromRgba(75, 192, 192, 0.4),
+                BorderColor = ChartColor.FromRgb(75,192,192),
                 BorderCapStyle = "butt",
                 BorderDash = new List<int> { },
                 BorderDashOffset = 0.0,
                 BorderJoinStyle = "miter",
-                PointBorderColor = new List<string> { "rgba(75,192,192,1)" },
-                PointBackgroundColor = new List<string> { "#fff" },
+                PointBorderColor = new List<ChartColor> { ChartColor.FromRgb(75,192,192) },
+                PointBackgroundColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
                 PointBorderWidth = new List<int> { 1 },
                 PointHoverRadius = new List<int> { 5 },
-                PointHoverBackgroundColor = new List<string> { "rgba(75,192,192,1)" },
-                PointHoverBorderColor = new List<string> { "rgba(220,220,220,1)" },
+                PointHoverBackgroundColor = new List<ChartColor> { ChartColor.FromRgb(75,192,192) },
+                PointHoverBorderColor = new List<ChartColor> { ChartColor.FromRgb(220,220,220) },
                 PointHoverBorderWidth = new List<int> { 2 },
                 PointRadius = new List<int> { 1 },
                 PointHitRadius = new List<int> { 10 },

--- a/src/ChartJSCoreTest/LineScatterChartTests.cs
+++ b/src/ChartJSCoreTest/LineScatterChartTests.cs
@@ -35,16 +35,16 @@ namespace ChartJSCoreTest
             var scatterData2 = new LineScatterData();
             var scatterData3 = new LineScatterData();
 
-            scatterData1.x = "-10";
-            scatterData1.y = "0";
+            scatterData1.X = "-10";
+            scatterData1.Y = "0";
             dataset.Data.Add(scatterData1);
 
-            scatterData2.x = "0";
-            scatterData2.y = "10";
+            scatterData2.X = "0";
+            scatterData2.Y = "10";
             dataset.Data.Add(scatterData2);
 
-            scatterData3.x = "10";
-            scatterData3.y = "5";
+            scatterData3.X = "10";
+            scatterData3.Y = "5";
             dataset.Data.Add(scatterData3);
 
             data.Datasets = new List<Dataset> { dataset };

--- a/src/ChartJSCoreTest/PieChartTests.cs
+++ b/src/ChartJSCoreTest/PieChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using NUnit.Framework;
 
@@ -7,7 +8,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class PieChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var pieChartElement = document.getElementById(\"pieChart\");\r\nvar pieChart = new Chart(pieChartElement, {\"type\":\"pie\",\"data\":{\"datasets\":[{\"type\":\"pie\",\"backgroundColor\":[\"#FF6384\",\"#36A2EB\",\"#FFCE56\"],\"hoverBackgroundColor\":[\"#FF6384\",\"#36A2EB\",\"#FFCE56\"],\"data\":[300.0,50.0,100.0],\"label\":\"My dataset\"}],\"labels\":[\"Red\",\"Blue\",\"Yellow\"]},\"options\":{}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var pieChartElement = document.getElementById(\"pieChart\");\r\nvar pieChart = new Chart(pieChartElement, {\"type\":\"pie\",\"data\":{\"datasets\":[{\"type\":\"pie\",\"backgroundColor\":[\"rgba(255, 99, 132, 1)\",\"rgba(54, 162, 235, 1)\",\"rgba(255, 206, 86, 1)\"],\"hoverBackgroundColor\":[\"rgba(255, 99, 132, 1)\",\"rgba(54, 162, 235, 1)\",\"rgba(255, 206, 86, 1)\"],\"data\":[300.0,50.0,100.0],\"label\":\"My dataset\"}],\"labels\":[\"Red\",\"Blue\",\"Yellow\"]},\"options\":{}}\r\n);";
 
         [Test]
         public void Generate_PieChart_Generates_Valid_Chart()
@@ -28,8 +29,18 @@ namespace ChartJSCoreTest
             var dataset = new PieDataset
             {
                 Label = "My dataset",
-                BackgroundColor = new List<string> { "#FF6384", "#36A2EB", "#FFCE56" },
-                HoverBackgroundColor = new List<string> { "#FF6384", "#36A2EB", "#FFCE56" },
+                BackgroundColor = new List<ChartColor>
+                {
+                    ChartColor.FromHexString("#FF6384"),
+                    ChartColor.FromHexString("#36A2EB"),
+                    ChartColor.FromHexString("#FFCE56")
+                },
+                HoverBackgroundColor = new List<ChartColor>
+                {
+                    ChartColor.FromHexString("#FF6384"),
+                    ChartColor.FromHexString("#36A2EB"),
+                    ChartColor.FromHexString("#FFCE56")
+                },
                 Data = new List<double> { 300, 50, 100 }
             };
 

--- a/src/ChartJSCoreTest/PolarChartTests.cs
+++ b/src/ChartJSCoreTest/PolarChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using NUnit.Framework;
 
@@ -7,7 +8,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class PolarChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var polarChartElement = document.getElementById(\"polarChart\");\r\nvar polarChart = new Chart(polarChartElement, {\"type\":\"polarArea\",\"data\":{\"datasets\":[{\"type\":\"polarArea\",\"backgroundColor\":[\"#FF6384\",\"#4BC0C0\",\"#FFCE56\",\"#E7E9ED\",\"#36A2EB\"],\"data\":[11.0,16.0,7.0,3.0,14.0],\"label\":\"My dataset\"}],\"labels\":[\"Red\",\"Green\",\"Yellow\",\"Grey\",\"Blue\"]},\"options\":{}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var polarChartElement = document.getElementById(\"polarChart\");\r\nvar polarChart = new Chart(polarChartElement, {\"type\":\"polarArea\",\"data\":{\"datasets\":[{\"type\":\"polarArea\",\"backgroundColor\":[\"rgba(255, 99, 132, 1)\",\"rgba(75, 192, 192, 1)\",\"rgba(255, 206, 86, 1)\",\"rgba(231, 233, 237, 1)\",\"rgba(54, 162, 235, 1)\"],\"data\":[11.0,16.0,7.0,3.0,14.0],\"label\":\"My dataset\"}],\"labels\":[\"Red\",\"Green\",\"Yellow\",\"Grey\",\"Blue\"]},\"options\":{}}\r\n);";
 
         [Test]
         public void Generate_PolarChart_Generates_Valid_Chart()
@@ -38,7 +39,14 @@ namespace ChartJSCoreTest
             var dataset = new PolarDataset
             {
                 Label = "My dataset",
-                BackgroundColor = new List<string> { "#FF6384", "#4BC0C0", "#FFCE56", "#E7E9ED", "#36A2EB" },
+                BackgroundColor = new List<ChartColor>
+                {
+                    ChartColor.FromHexString("#FF6384"),
+                    ChartColor.FromHexString("#4BC0C0"),
+                    ChartColor.FromHexString("#FFCE56"),
+                    ChartColor.FromHexString("#E7E9ED"),
+                    ChartColor.FromHexString("#36A2EB")
+                },
                 Data = new List<double> { 11, 16, 7, 3, 14 }
             };
 

--- a/src/ChartJSCoreTest/RadarChartTests.cs
+++ b/src/ChartJSCoreTest/RadarChartTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJSCore.Helpers;
 using ChartJSCore.Models;
 using NUnit.Framework;
 
@@ -7,7 +8,7 @@ namespace ChartJSCoreTest
     [TestFixture]
     public class RadarChartTests
     {
-        private const string KNOWN_GOOD_CHART = "var radarChartElement = document.getElementById(\"radarChart\");\r\nvar radarChart = new Chart(radarChartElement, {\"type\":\"radar\",\"data\":{\"datasets\":[{\"type\":\"radar\",\"backgroundColor\":\"rgba(179,181,198,0.2)\",\"borderColor\":\"rgba(179,181,198,1)\",\"pointBorderColor\":\"#fff\",\"pointBackgroundColor\":\"rgba(179,181,198,1)\",\"pointHoverBackgroundColor\":\"#fff\",\"pointHoverBorderColor\":\"rgba(179,181,198,1)\",\"data\":[65.0,59.0,80.0,81.0,56.0,55.0,40.0],\"label\":\"My First dataset\"},{\"type\":\"radar\",\"backgroundColor\":\"rgba(255,99,132,0.2)\",\"borderColor\":\"rgba(255,99,132,1)\",\"pointBorderColor\":\"#fff\",\"pointBackgroundColor\":\"rgba(255,99,132,1)\",\"pointHoverBackgroundColor\":\"#fff\",\"pointHoverBorderColor\":\"rgba(255,99,132,1)\",\"data\":[28.0,48.0,40.0,19.0,96.0,27.0,100.0],\"label\":\"My Second dataset\"}],\"labels\":[\"Eating\",\"Drinking\",\"Sleeping\",\"Designing\",\"Coding\",\"Cycling\",\"Running\"]},\"options\":{}}\r\n);";
+        private const string KNOWN_GOOD_CHART = "var radarChartElement = document.getElementById(\"radarChart\");\r\nvar radarChart = new Chart(radarChartElement, {\"type\":\"radar\",\"data\":{\"datasets\":[{\"type\":\"radar\",\"backgroundColor\":\"rgba(179, 181, 198, 0.2)\",\"borderColor\":\"rgba(179, 181, 198, 1)\",\"pointBorderColor\":\"rgba(255, 255, 255, 1)\",\"pointBackgroundColor\":\"rgba(179, 181, 198, 1)\",\"pointHoverBackgroundColor\":\"rgba(255, 255, 255, 1)\",\"pointHoverBorderColor\":\"rgba(179, 181, 198, 1)\",\"data\":[65.0,59.0,80.0,81.0,56.0,55.0,40.0],\"label\":\"My First dataset\"},{\"type\":\"radar\",\"backgroundColor\":\"rgba(255, 99, 132, 0.2)\",\"borderColor\":\"rgba(255, 99, 132, 1)\",\"pointBorderColor\":\"rgba(255, 255, 255, 1)\",\"pointBackgroundColor\":\"rgba(255, 99, 132, 1)\",\"pointHoverBackgroundColor\":\"rgba(255, 255, 255, 1)\",\"pointHoverBorderColor\":\"rgba(255, 99, 132, 1)\",\"data\":[28.0,48.0,40.0,19.0,96.0,27.0,100.0],\"label\":\"My Second dataset\"}],\"labels\":[\"Eating\",\"Drinking\",\"Sleeping\",\"Designing\",\"Coding\",\"Cycling\",\"Running\"]},\"options\":{}}\r\n);";
 
         [Test]
         public void Generate_RadarChart_Generates_Valid_Chart()
@@ -40,24 +41,24 @@ namespace ChartJSCoreTest
             var dataset1 = new RadarDataset
             {
                 Label = "My First dataset",
-                BackgroundColor = "rgba(179,181,198,0.2)",
-                BorderColor = "rgba(179,181,198,1)",
-                PointBackgroundColor = new List<string> { "rgba(179,181,198,1)" },
-                PointBorderColor = new List<string> { "#fff" },
-                PointHoverBackgroundColor = new List<string> { "#fff" },
-                PointHoverBorderColor = new List<string> { "rgba(179,181,198,1)" },
+                BackgroundColor = ChartColor.FromRgba(179,181,198,0.2),
+                BorderColor = ChartColor.FromRgb(179,181,198),
+                PointBackgroundColor = new List<ChartColor> { ChartColor.FromRgb(179, 181, 198) },
+                PointBorderColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
+                PointHoverBackgroundColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
+                PointHoverBorderColor = new List<ChartColor> { ChartColor.FromRgb(179, 181, 198) },
                 Data = new List<double> { 65, 59, 80, 81, 56, 55, 40 }
             };
 
             var dataset2 = new RadarDataset
             {
                 Label = "My Second dataset",
-                BackgroundColor = "rgba(255,99,132,0.2)",
-                BorderColor = "rgba(255,99,132,1)",
-                PointBackgroundColor = new List<string> { "rgba(255,99,132,1)" },
-                PointBorderColor = new List<string> { "#fff" },
-                PointHoverBackgroundColor = new List<string> { "#fff" },
-                PointHoverBorderColor = new List<string> { "rgba(255,99,132,1)" },
+                BackgroundColor = ChartColor.FromRgba(255,99,132,0.2),
+                BorderColor = ChartColor.FromRgb(255, 99, 132),
+                PointBackgroundColor = new List<ChartColor> { ChartColor.FromRgb(255, 99, 132) },
+                PointBorderColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
+                PointHoverBackgroundColor = new List<ChartColor> { ChartColor.FromHexString("#ffffff") },
+                PointHoverBorderColor = new List<ChartColor> { ChartColor.FromRgb(255, 99, 132) },
                 Data = new List<double> { 28, 48, 40, 19, 96, 27, 100 }
             };
 


### PR DESCRIPTION
I proposed in a earlier, that we should use a color-object instead of a plain string. This was sadly not possible, because in .Net standard the `System.Drawing` namespace isn't available.
So I wrote a custom color-class. To prevent namespace-issues, I name the class `ChartColor` and not `Color`. I added a bunch of unit tests for this new class and adjusted the existing so that they all pass.

I really hope that this huge PR gets merged :)