### PR TITLE
Added classes for handling color plugin

### DIFF
--- a/src/ChartJSCore/Models/Options/ColorPlugin.cs
+++ b/src/ChartJSCore/Models/Options/ColorPlugin.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ChartJSCore.Models
+{
+    public class ColorPlugin
+    {
+        /// <summary>
+        /// The color plugin is enabled by default, It might be disabled if necessary.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// You can force ChartJS to use your own colors instead of the standard colors
+        /// </summary>
+        public bool? ForceOverride { get; set; }
+    }
+}

--- a/src/ChartJSCore/Models/Options/Plugins.cs
+++ b/src/ChartJSCore/Models/Options/Plugins.cs
@@ -25,5 +25,11 @@ namespace ChartJSCore.Models
         /// The global options for the chart tooltips.
         /// </summary>
         public ToolTip Tooltip { get; set; }
+
+        /// <summary>
+        /// Allow to modify color options used for displaying the datasets.
+        /// The plugin is included in Chart.js by default.
+        /// </summary>
+        public ColorPlugin Colors { get; set; }
     }
 }


### PR DESCRIPTION
Hi Matt,
The color plugin is shiping with Chart.js. In order to use it, it was needed to use pluginDynamic. Unfortunately, this hinders using further options plugins (like legend settings). I added some documentation, if you want more/ different documentation, please let me know.
Also, if you want the plugin to move to plugins directory (where the zoom plugin resides), just let me know as well.